### PR TITLE
fix: apply BLOCKED_APPS to VpnService builder in Android SS/Xray mode

### DIFF
--- a/packages/flutter_vless_android/android/src/main/kotlin/com/github/tfox/flutter_vless/xray/service/XrayVPNService.kt
+++ b/packages/flutter_vless_android/android/src/main/kotlin/com/github/tfox/flutter_vless/xray/service/XrayVPNService.kt
@@ -125,11 +125,20 @@ class XrayVPNService : VpnService() {
                 builder.setMetered(false)
             }
             
-            try {
-                builder.addDisallowedApplication(packageName)
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to exclude app from VPN", e)
-            }
+          try {
+    builder.addDisallowedApplication(packageName)
+} catch (e: Exception) {
+    Log.e(TAG, "Failed to exclude app from VPN", e)
+}
+
+for (pkg in config.BLOCKED_APPS) {
+    try {
+        builder.addDisallowedApplication(pkg)
+        Log.d(TAG, "Excluded from VPN: $pkg")
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to exclude $pkg from VPN", e)
+    }
+}
 
             // Add routes to exclude the server IP (to prevent routing loop)
             val serverIp = config.CONNECTED_V2RAY_SERVER_ADDRESS


### PR DESCRIPTION
The Android VpnService setup in XrayVPNService.kt only excluded the 
app's own package from the VPN tunnel via addDisallowedApplication(packageName). 
The BLOCKED_APPS list passed from Dart (via startVless's blockedApps param) 
was received into XrayConfig but never actually applied to the VpnService.Builder.

This meant per-app VPN exclusion (split tunneling) silently did nothing in 
VPN mode when using Shadowsocks/Xray-based configs, even though the same 
feature worked correctly for other connection types.

Fix: loop through config.BLOCKED_APPS and call addDisallowedApplication() 
for each package, same as already done for the app's own package.

Tested on a real Android device — confirmed apps added to blockedApps now 
correctly bypass the VPN tunnel while others remain protected.