### PR TITLE
ios: cap h2 upload scratch buffer via patched GOROOT clone (fixes #23)

### DIFF
--- a/ios/XRAY_BUILD.md
+++ b/ios/XRAY_BUILD.md
@@ -42,3 +42,18 @@ before running `go get` and `go mod tidy`, so the tracked vendored source is not
 mutated by release builds.
 
 Note: Xcode Command Line Tools are not enough because `gomobile bind -target=ios` needs the `iphoneos` and `iphonesimulator` SDKs.
+
+## H2BUF scratch-buffer patch
+
+The build script patches a temporary copy of the Go standard library before
+`gomobile bind`: it clones the live GOROOT into `ios/build_xray_ios/goroot-patched`
+and lowers the http2 client's per-stream upload scratch buffer cap from 512 KiB
+to 128 KiB (`H2BUF_CAP_KB` overrides the value, range 16-512). The system Go
+installation is never modified.
+
+Without this cap, Xray's XHTTP server advertises a 1 MiB SETTINGS_MAX_FRAME_SIZE
+and iOS Network Extensions (50 MB hard limit) are jetsam-killed under concurrent
+uploads. See issue #23 for the full analysis and on-device measurements.
+
+Tested toolchain: **Go 1.27** (any Go >= 1.25 stdlib layout should work; the
+build fails with a clear error if the stdlib layout or anchor line changes).

--- a/ios/XRAY_BUILD.md
+++ b/ios/XRAY_BUILD.md
@@ -4,12 +4,12 @@ The iOS plugin uses `XRay.xcframework`, generated with `gomobile bind` from
 the vendored `third_party/xray-mobile` Go wrapper.
 
 Current target Xray-core version: `v26.7.11`.
-Release commit used by the script: `45cf2898ab12e97a55dd8f1f3d78d903340bdc9e`.
+Release commit used by the script: `50231eaff98ccc31b5cbd247a721c16e97fe5ec1`.
 
 Requirements:
 
 - Full Xcode with iOS SDK installed and selected with `xcode-select`.
-- Go installed.
+- Go 1.27 or newer installed.
 - `gomobile` installed, or let the script install it into `$HOME/go/bin`.
 
 Build:
@@ -34,7 +34,7 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./ios/build_xray_ios.sh
 Useful overrides:
 
 ```bash
-XRAY_MOBILE_DIR=../third_party/xray-mobile XRAY_CORE_REF=45cf2898ab12e97a55dd8f1f3d78d903340bdc9e IOS_VERSION=15.0 ./build_xray_ios.sh
+XRAY_MOBILE_DIR=../third_party/xray-mobile XRAY_CORE_REF=50231eaff98ccc31b5cbd247a721c16e97fe5ec1 IOS_VERSION=15.0 ./build_xray_ios.sh
 ```
 
 The build script copies `XRAY_MOBILE_DIR` into `ios/build_xray_ios/xray-mobile`
@@ -55,5 +55,5 @@ Without this cap, Xray's XHTTP server advertises a 1 MiB SETTINGS_MAX_FRAME_SIZE
 and iOS Network Extensions (50 MB hard limit) are jetsam-killed under concurrent
 uploads. See issue #23 for the full analysis and on-device measurements.
 
-Tested toolchain: **Go 1.27** (any Go >= 1.25 stdlib layout should work; the
-build fails with a clear error if the stdlib layout or anchor line changes).
+Required and tested toolchain: **Go 1.27 or newer**. The build fails with a
+clear error if the Go version, stdlib layout, or anchor line is unsupported.

--- a/ios/build_xray_ios.sh
+++ b/ios/build_xray_ios.sh
@@ -47,6 +47,66 @@ go get "github.com/xtls/xray-core@$XRAY_CORE_REF"
 go get -tool golang.org/x/mobile/cmd/gobind
 go mod tidy
 
+# ---------------------------------------------------------------------------
+# H2BUF patch: cap the Go http2 client's per-stream upload scratch buffer.
+#
+# Why: Go's h2 client sizes this buffer as min(server-advertised
+# SETTINGS_MAX_FRAME_SIZE, 512 KiB) and never shrinks it for streaming POSTs
+# without Content-Length (the XHTTP uplink). Xray's XHTTP server advertises
+# the Go default of 1 MiB, so every concurrent upload stream costs 512 KiB.
+# Inside an iOS Network Extension (hard 50 MB limit) 35-45 concurrent streams
+# exceed the budget and the extension is jetsam-killed. See issue #23.
+#
+# How: clone the live GOROOT (APFS copy-on-write, instant) and patch the
+# stdlib file in the clone only; the system Go installation is never touched.
+# The patch targets the Go >= 1.25 stdlib layout (http2 vendored at
+# net/http/internal/http2); tested with Go 1.27. If the layout or the anchor
+# line changes in a future Go release, the build fails loudly below instead
+# of silently shipping an unpatched framework.
+#
+# Override the cap with H2BUF_CAP_KB (default 128; 16-512 accepted).
+# ---------------------------------------------------------------------------
+H2BUF_CAP_KB="${H2BUF_CAP_KB:-128}"
+case "$H2BUF_CAP_KB" in
+    ''|*[!0-9]*) echo "Error: H2BUF_CAP_KB must be a number (got '$H2BUF_CAP_KB')"; exit 1 ;;
+esac
+if [ "$H2BUF_CAP_KB" -lt 16 ] || [ "$H2BUF_CAP_KB" -gt 512 ]; then
+    echo "Error: H2BUF_CAP_KB must be between 16 and 512 (got $H2BUF_CAP_KB)"
+    exit 1
+fi
+
+GOROOT_LIVE="$(go env GOROOT)"
+GOROOT_PATCHED="$BUILD_DIR/goroot-patched"
+H2_REL="src/net/http/internal/http2/transport.go"
+if [ ! -f "$GOROOT_LIVE/$H2_REL" ]; then
+    echo "Error: $H2_REL not found in GOROOT ($GOROOT_LIVE)."
+    echo "The H2BUF patch supports the Go >= 1.25 stdlib http2 layout (tested: Go 1.27)."
+    echo "Your Go version: $(go version)"
+    exit 1
+fi
+rm -rf "$GOROOT_PATCHED"
+cp -Rc "$GOROOT_LIVE" "$GOROOT_PATCHED" 2>/dev/null || cp -R "$GOROOT_LIVE" "$GOROOT_PATCHED"
+H2_FILE="$GOROOT_PATCHED/$H2_REL"
+H2BUF_CAP_KB="$H2BUF_CAP_KB" python3 - "$H2_FILE" <<'PYEOF'
+import os, sys
+path = sys.argv[1]
+cap = os.environ["H2BUF_CAP_KB"]
+src = open(path).read()
+old = "const max = 512 << 10"
+n = src.count(old)
+if n != 1:
+    sys.stderr.write(
+        f"Error: expected exactly one occurrence of '{old}' in {path}, found {n}.\n"
+        "The Go stdlib http2 source has changed; update the H2BUF patch anchor.\n")
+    sys.exit(1)
+open(path, "w").write(src.replace(old, f"const max = {cap} << 10 // H2BUF patch (flutter_vless issue #23)"))
+print(f"H2BUF: capped h2 upload scratch buffer at {cap} KiB in GOROOT clone")
+PYEOF
+export GOROOT="$GOROOT_PATCHED"
+export PATH="$GOROOT_PATCHED/bin:$PATH"
+grep -q "H2BUF patch" "$H2_FILE" || { echo "Error: H2BUF patch verification failed"; exit 1; }
+echo "H2BUF: building with $(go version) from patched GOROOT clone"
+
 rm -rf "$OUTPUT_XCFRAMEWORK"
 gomobile bind \
     -a \

--- a/ios/build_xray_ios.sh
+++ b/ios/build_xray_ios.sh
@@ -15,6 +15,19 @@ if ! command -v go >/dev/null 2>&1; then
     exit 1
 fi
 
+GO_VERSION="$(go env GOVERSION)"
+if [[ ! "$GO_VERSION" =~ ^go([0-9]+)\.([0-9]+) ]]; then
+    echo "Error: unable to parse Go version '$GO_VERSION'. Go 1.27 or newer is required."
+    exit 1
+fi
+GO_MAJOR="${BASH_REMATCH[1]}"
+GO_MINOR="${BASH_REMATCH[2]}"
+if [ "$GO_MAJOR" -lt 1 ] || { [ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 27 ]; }; then
+    echo "Error: Go 1.27 or newer is required for the stdlib http2 layout used by the H2BUF patch."
+    echo "Your Go version: $(go version)"
+    exit 1
+fi
+
 if ! command -v gomobile >/dev/null 2>&1; then
     echo "gomobile not found, installing it with go install..."
     go install golang.org/x/mobile/cmd/gomobile@latest
@@ -59,7 +72,7 @@ go mod tidy
 #
 # How: clone the live GOROOT (APFS copy-on-write, instant) and patch the
 # stdlib file in the clone only; the system Go installation is never touched.
-# The patch targets the Go >= 1.25 stdlib layout (http2 vendored at
+# The patch targets the Go >= 1.27 stdlib layout (http2 vendored at
 # net/http/internal/http2); tested with Go 1.27. If the layout or the anchor
 # line changes in a future Go release, the build fails loudly below instead
 # of silently shipping an unpatched framework.
@@ -80,12 +93,15 @@ GOROOT_PATCHED="$BUILD_DIR/goroot-patched"
 H2_REL="src/net/http/internal/http2/transport.go"
 if [ ! -f "$GOROOT_LIVE/$H2_REL" ]; then
     echo "Error: $H2_REL not found in GOROOT ($GOROOT_LIVE)."
-    echo "The H2BUF patch supports the Go >= 1.25 stdlib http2 layout (tested: Go 1.27)."
+    echo "The H2BUF patch requires the Go >= 1.27 stdlib http2 layout."
     echo "Your Go version: $(go version)"
     exit 1
 fi
 rm -rf "$GOROOT_PATCHED"
 cp -Rc "$GOROOT_LIVE" "$GOROOT_PATCHED" 2>/dev/null || cp -R "$GOROOT_LIVE" "$GOROOT_PATCHED"
+# Toolchains downloaded through GOTOOLCHAIN live in the read-only module cache.
+# Make only the temporary clone writable so it can be patched and removed later.
+chmod -R u+w "$GOROOT_PATCHED"
 H2_FILE="$GOROOT_PATCHED/$H2_REL"
 H2BUF_CAP_KB="$H2BUF_CAP_KB" python3 - "$H2_FILE" <<'PYEOF'
 import os, sys


### PR DESCRIPTION
Fixes #23, as requested in the maintainer review comment there.

## What this does

`ios/build_xray_ios.sh` now patches a **temporary GOROOT clone** before `gomobile bind`, capping the Go http2 client's per-stream upload scratch buffer (`const max = 512 << 10` in `net/http/internal/http2/transport.go`). Without the cap, Xray's XHTTP server advertises a 1 MiB SETTINGS_MAX_FRAME_SIZE, every CL-less streaming upload stream costs 512 KiB on the client, and iOS Network Extensions (50 MB hard limit) are jetsam-killed under 35-45 concurrent streams. Full analysis and measurements in #23.

## Review checklist (from the maintainer comment)

- **Temporary GOROOT copy only** — the live GOROOT is cloned into `$BUILD_DIR/goroot-patched` (APFS `cp -Rc` copy-on-write, with plain `cp -R` fallback); the system Go installation is never touched. The clone lives inside the already-gitignored build dir and is recreated each build.
- **Anchor verified exactly once** — the patch asserts the anchor line occurs exactly once and exits with a clear error naming the file and the anchor if the count differs. A post-patch grep guard additionally fails the build if the patched marker is absent.
- **Go version handled deliberately** — the script checks that `src/net/http/internal/http2/transport.go` exists in the GOROOT before patching (the Go >= 1.27 stdlib layout, where x/net/http2's client is a wrapper over the stdlib implementation) and errors with the detected `go version` if not. XRAY_BUILD.md now documents the mechanism and states Go 1.27 as the tested toolchain.

## Cap value

Default is **128 KiB** with `H2BUF_CAP_KB` env override (validated range 16-512), per the A/B data posted in #23: 16, 128, and 256 KiB all passed the full on-device repro suite with zero jetsam kills; 128 KiB keeps worst-case buffer usage at ~10 MB for 80 concurrent streams while 512 KiB is the proven-fatal original. Throughput was indistinguishable between 16 and 128. If you prefer 16 KiB as the default, it's a one-character change — happy to flip it.

## Verification

- `bash -n` clean
- Built the XCFramework with this exact script and ran it on a real device (iOS 26.6, Reality + XHTTP stream-up, no CDN): buffers 128 KiB/stream via `runtime.MemProfile`, heap stable at 13-14 MB through 1,100+ goroutine bursts, zero jetsam kills across repeated connection-heavy app open/close cycles and full speedtests. Pre-patch the extension died within 2 minutes every run (kernel: `memorystatus: exceeded mem limit: ActiveHard 50 MB (fatal)`).