### PR TITLE
Fix macOS CI signing and Windows registration include

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
         run: flutter build ios --debug --no-codesign
       - name: Build example macOS app
         working-directory: example
+        env:
+          FLUTTER_XCODE_CODE_SIGNING_ALLOWED: "NO"
         run: flutter build macos --debug
 
   windows:

--- a/packages/flutter_vless_windows/windows/include/flutter_vless_windows/flutter_vless_plugin.h
+++ b/packages/flutter_vless_windows/windows/include/flutter_vless_windows/flutter_vless_plugin.h
@@ -1,0 +1,7 @@
+#ifndef FLUTTER_VLESS_WINDOWS_REGISTRATION_H_
+#define FLUTTER_VLESS_WINDOWS_REGISTRATION_H_
+
+// Flutter generates this include path from the federated package name.
+#include <flutter_vless/flutter_vless_plugin.h>
+
+#endif  // FLUTTER_VLESS_WINDOWS_REGISTRATION_H_


### PR DESCRIPTION
The macOS CI build stopped at provisioning because the disposable runner has no development profiles. Disable signing only for that CI build so both the app and extension compile without account credentials.

The federated Windows package generates an include under `flutter_vless_windows`, while the existing public header lives under `flutter_vless`. Add a forwarding header at the generated path, retaining the existing include for source compatibility.

Validation: [CI run 34052080155](https://github.com/XIIIFOX/flutter_vless/actions/runs/34052080155) passed all five jobs: Dart/Flutter, Android native tests and Maven Central resolution, Android emulator runtime smoke, iOS/macOS builds, and Windows native diagnostics plus application build. No VPN routing or runtime behavior changes.
